### PR TITLE
Import new changes from madgraph5/madgraph4gpu#752

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,10 @@
 # Created by: O. Mattelaer (Sep 2021) for the MG5aMC CUDACPP plugin.
 # Further modified by: O. Mattelaer, A. Valassi (2021-2023) for the MG5aMC CUDACPP plugin.
 
-print('Load PLUGIN.CUDACPP_SA_OUTPUT')
+# AV - Rename the plugin as CUDACPP_OUTPUT (was CUDACPP_SA_OUTPUT)
+# [NB: madgraph4gpu's directory CUDACPP_SA_OUTPUT is copied to mg5amcnlo as directory CUDACPP_OUTPUT]
+# [NB: eventually, the git repo mg5amcnlo_cudacpp will become mg5amcnlo's submodule CUDACPP_OUTPUT]
+print('Load PLUGIN.CUDACPP_OUTPUT')
 
 # AV - Require Python >= 3.8 to ensure that {} dictionaries preserve the order of item insertion
 # (note: python3.7 would probably be enough but this plugin has only been tested using python3.8)
@@ -11,7 +14,7 @@ import sys
 minpython = (3,8)
 if sys.version_info < minpython :
 
-    print('ERROR! Cannot load PLUGIN.CUDACPP_SA_OUTPUT: Python >= %s.%s is required' % minpython)
+    print('ERROR! Cannot load PLUGIN.CUDACPP_OUTPUT: Python >= %s.%s is required' % minpython)
 
 else:
 
@@ -28,7 +31,7 @@ else:
     #    Example: new_output = {'myformat': MYCLASS}
     #    allows the command "output myformat PATH" in madgraph.
     #    MYCLASS should inherit from class madgraph.iolibs.export_v4.VirtualExporter
-    import PLUGIN.CUDACPP_SA_OUTPUT.output as output
+    import PLUGIN.CUDACPP_OUTPUT.output as output
     new_output = { 'standalone_cudacpp' : output.PLUGIN_ProcessExporter }
 
     # 2. Define new way to handle the cluster.

--- a/model_handling.py
+++ b/model_handling.py
@@ -11,14 +11,14 @@ PLUGINDIR = os.path.dirname( __file__ )
 
 # AV - create a plugin-specific logger
 import logging
-logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_SA_OUTPUT.model_handling')
+logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_OUTPUT.model_handling')
 
 #------------------------------------------------------------------------------------
 
 # AV - import the independent 2nd copy of the export_cpp module (as PLUGIN_export_cpp), previously loaded in output.py
 ###import madgraph.iolibs.export_cpp as export_cpp # 1st copy
 ######import madgraph.iolibs.export_cpp as PLUGIN_export_cpp # this is not enough to define an independent 2nd copy: id(export_cpp)==id(PLUGIN_export_cpp)
-import PLUGIN.CUDACPP_SA_OUTPUT.PLUGIN_export_cpp as PLUGIN_export_cpp # 2nd copy loaded in the plugin's output.py
+import PLUGIN.CUDACPP_OUTPUT.PLUGIN_export_cpp as PLUGIN_export_cpp # 2nd copy loaded in the plugin's output.py
 ###print('id(export_cpp)=%s'%id(export_cpp))
 ###print('id(PLUGIN_export_cpp)=%s'%id(PLUGIN_export_cpp))
 
@@ -41,7 +41,7 @@ import importlib.util
 SPEC_WRITERS = importlib.util.find_spec('madgraph.iolibs.file_writers')
 PLUGIN_writers = importlib.util.module_from_spec(SPEC_WRITERS)
 SPEC_WRITERS.loader.exec_module(PLUGIN_writers)
-###sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.PLUGIN_writers'] = PLUGIN_writers # would allow 'import PLUGIN.CUDACPP_SA_OUTPUT.PLUGIN_writers' (not needed)
+###sys.modules['PLUGIN.CUDACPP_OUTPUT.PLUGIN_writers'] = PLUGIN_writers # would allow 'import PLUGIN.CUDACPP_OUTPUT.PLUGIN_writers' (not needed)
 del SPEC_WRITERS
 
 # AV - use the independent 2nd copy of the writers module within the PLUGIN_export_cpp module (workaround for #341)

--- a/output.py
+++ b/output.py
@@ -14,7 +14,7 @@ import importlib.util
 SPEC_EXPORTCPP = importlib.util.find_spec('madgraph.iolibs.export_cpp')
 PLUGIN_export_cpp = importlib.util.module_from_spec(SPEC_EXPORTCPP)
 SPEC_EXPORTCPP.loader.exec_module(PLUGIN_export_cpp)
-sys.modules['PLUGIN.CUDACPP_SA_OUTPUT.PLUGIN_export_cpp'] = PLUGIN_export_cpp # allow 'import PLUGIN.CUDACPP_SA_OUTPUT.PLUGIN_export_cpp' in model_handling.py
+sys.modules['PLUGIN.CUDACPP_OUTPUT.PLUGIN_export_cpp'] = PLUGIN_export_cpp # allow 'import PLUGIN.CUDACPP_OUTPUT.PLUGIN_export_cpp' in model_handling.py
 del SPEC_EXPORTCPP
 ###print('id(export_cpp)=%s'%id(export_cpp))
 ###print('id(PLUGIN_export_cpp)=%s'%id(PLUGIN_export_cpp))
@@ -24,11 +24,11 @@ del SPEC_EXPORTCPP
 PLUGINDIR = os.path.dirname( __file__ )
 
 # AV - model_handling includes the custom FileWriter, ALOHAWriter, UFOModelConverter, OneProcessExporter and HelasCallWriter, plus additional patches
-import PLUGIN.CUDACPP_SA_OUTPUT.model_handling as model_handling
+import PLUGIN.CUDACPP_OUTPUT.model_handling as model_handling
 
 # AV - create a plugin-specific logger
 import logging
-logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_SA_OUTPUT.output')
+logger = logging.getLogger('madgraph.PLUGIN.CUDACPP_OUTPUT.output')
 
 #------------------------------------------------------------------------------------
 
@@ -206,7 +206,7 @@ class PLUGIN_ProcessExporter(PLUGIN_export_cpp.ProcessExporterGPU):
             self.add_input_for_banner()
             if 'CUDACPP_CODEGEN_PATCHLEVEL' in os.environ: patchlevel = os.environ['CUDACPP_CODEGEN_PATCHLEVEL']
             else: patchlevel = ''
-            path = os.path.realpath(os.curdir + os.sep + 'PLUGIN' + os.sep + 'CUDACPP_SA_OUTPUT')
+            path = os.path.realpath(os.curdir + os.sep + 'PLUGIN' + os.sep + 'CUDACPP_OUTPUT')
             if os.system(path + os.sep + 'patchMad.sh ' + self.dir_path + ' PROD ' + patchlevel) != 0:
                 raise Exception('ERROR! the O/S call to patchMad.sh failed')
         return super().finalize(matrix_element, cmdhistory, MG5options, outputflag)


### PR DESCRIPTION
Import new changes from madgraph5/madgraph4gpu#752

These are some name changes I included in the MR making mg5amcnlo a submodule of madgraph4gpu, but they were really targeting the eventual includion of mg5amcnlo_cudacpp as a git submodule of mg5amcnlo